### PR TITLE
Add Scratchpad node types and update codegen/serializer

### DIFF
--- a/PCSX2PluginExt.cs
+++ b/PCSX2PluginExt.cs
@@ -12,9 +12,9 @@ namespace PCSX2Plugin
 		{
 			return new CustomNodeTypes
 			{
-				CodeGenerator = new PS2PtrCodeGenerator(),
-				Serializer = new PS2PtrNodeConverter(),
-				NodeTypes = new[] { typeof(EEMemNode), typeof(PS2PtrNode) }
+				CodeGenerator = new PS2CodeGenerator(),
+				Serializer = new PS2NodeSerializer(),
+				NodeTypes = new[] { typeof(EEMemNode), typeof(PS2PtrNode), typeof(ScratchpadNode), typeof(PS2ScratchPtrNode) }
 			};
 		}
 	}

--- a/PS2PtrCodeGenerator.cs
+++ b/PS2PtrCodeGenerator.cs
@@ -1,24 +1,45 @@
 ﻿using ReClassNET.CodeGenerator;
 using ReClassNET.Logger;
 using ReClassNET.Nodes;
+using System.Collections.Generic;
+using System;
 
 namespace PCSX2Plugin
 {
-	public class PS2PtrCodeGenerator : CustomCppCodeGenerator
-	{
-		public override bool CanHandle(BaseNode node)
-		{
-			return node is PS2PtrNode;
-		}
-		
-		public override BaseNode TransformNode(BaseNode node)
-		{
-			return node;
-		}
-		
-		public override string GetTypeDefinition(BaseNode node, GetTypeDefinitionFunc defaultGetTypeDefinitionFunc, ResolveWrappedTypeFunc defaultResolveWrappedTypeFunc, ILogger logger)
-		{
-			return $"class {((PS2PtrNode)node).InnerNode.Name} *";
-		}
-	}
+    public class PS2CodeGenerator : CustomCppCodeGenerator
+    {
+        // Map supported node types to how they should be printed
+        private static readonly Dictionary<Type, Func<BaseNode, string>> TypePrinters =
+            new Dictionary<Type, Func<BaseNode, string>>
+            {
+            { typeof(PS2PtrNode), node => $"class {((PS2PtrNode)node).InnerNode.Name} *" },
+            { typeof(PS2ScratchPtrNode), node => $"class {((PS2ScratchPtrNode)node).InnerNode.Name} *" }
+            };
+
+        public override bool CanHandle(BaseNode node)
+        {
+            return TypePrinters.ContainsKey(node.GetType());
+        }
+
+        public override BaseNode TransformNode(BaseNode node)
+        {
+            // No transformation needed for these custom nodes
+            return node;
+        }
+
+        public override string GetTypeDefinition(
+            BaseNode node,
+            GetTypeDefinitionFunc defaultGetTypeDefinitionFunc,
+            ResolveWrappedTypeFunc defaultResolveWrappedTypeFunc,
+            ILogger logger)
+        {
+            if (TypePrinters.TryGetValue(node.GetType(), out var printer))
+            {
+                return printer(node);
+            }
+
+            logger.Log(LogLevel.Error, $"No code generator for node type: {node.GetType().Name}");
+            return null; // fallback to nothing
+        }
+    }
 }


### PR DESCRIPTION
This pull request extends the PCSX2 plugin's support for custom node types and improves the code generation and serialization logic for PS2-specific pointer nodes. The main changes include adding support for new node types representing scratchpad memory, refactoring the code generator and serializer to handle multiple node types, and introducing helper classes for PS2 memory layout and scratchpad address resolution.

**Support for new node types and UI features:**

* Added two new node types, `ScratchpadNode` and `PS2ScratchPtrNode`, which represent PS2 scratchpad memory and pointers to it. These nodes include custom drawing and height calculation logic for the UI and are now registered in the plugin. [[1]](diffhunk://#diff-b253679dca62b3482e512c89ea6699bdb13a0f7c414d1182f2190aa48e495ba8R105-R196) [[2]](diffhunk://#diff-b253679dca62b3482e512c89ea6699bdb13a0f7c414d1182f2190aa48e495ba8R296-R395) [[3]](diffhunk://#diff-ae7d068d6da308c1c0e7eb76bb3760b4afd2bd838b267156d49f19ddba2f28acL15-R17)

**Refactoring and extensibility:**

* Refactored the code generator from `PS2PtrCodeGenerator` to `PS2CodeGenerator`, enabling support for multiple node types using a type-printer mapping for code generation.
* Refactored the serializer from `PS2PtrNodeConverter` to `PS2NodeSerializer`, allowing serialization and deserialization of multiple node types via type-to-XML and XML-to-type dictionaries.

**PS2 memory mapping and helpers:**

* Added the `PS2MemSize` static class to define offsets and sizes for PS2 memory regions, including scratchpad memory.
* Added the `GetScratchpad` helper method to resolve the base address of the scratchpad region based on the emulated memory layout.